### PR TITLE
Fix compile warnings

### DIFF
--- a/lib/encoders/json.ex
+++ b/lib/encoders/json.ex
@@ -1,8 +1,6 @@
 defmodule Tacos.Encoders.Json do
   @behaviour Tacos.Encoder
 
-  alias Poison.Encoder
-
   def encode(data) when is_list(data) or is_map(data) do
     "#{Poison.Encoder.encode(data, nil)}"
   end

--- a/lib/tacos.ex
+++ b/lib/tacos.ex
@@ -33,7 +33,7 @@ defmodule Tacos do
       {:ok, file} ->
         file
 
-      {:error, file} ->
+      {:error, _file} ->
         raise "Taco fetch error! The taco (#{taco}) exists but cannot be read."
     end
   end


### PR DESCRIPTION
One of the warnings seems to be related to an intermittent failure to compile tacos as a dependency.

```
== Compilation error on file lib/tacos.ex ==
** (ArgumentError) argument error
    (stdlib) :io.put_chars(:standard_error, :unicode, [['lib/tacos.ex', 58, '36', 58, 32], 'warning: ', [118, 97, 114, 105, 97, 98, 108, 101, 32, 'file', 32, 105, 115, 32, 117, 110, 117, 115,
    (elixir) src/elixir_errors.erl:267: :elixir_errors.do_warn/1
    (stdlib) lists.erl:1337: :lists.foreach/2
    (stdlib) erl_eval.erl:669: :erl_eval.do_apply/6
```
